### PR TITLE
Review code written for this function

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -2,8 +2,6 @@
 
 namespace romansorin\Http\Controllers;
 
-use Illuminate\Http\Request;
-
 class DashboardController extends Controller
 {
     /**
@@ -14,6 +12,7 @@ class DashboardController extends Controller
     public function __construct()
     {
         $this->middleware('auth');
+        $this->middleware('verified');
     }
 
     /**

--- a/app/Notifications/ResetPasswordNotification.php
+++ b/app/Notifications/ResetPasswordNotification.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace romansorin\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class ResetPasswordNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+                    ->line('The introduction to the notification.')
+                    ->action('Notification Action', url('/'))
+                    ->line('Thank you for using our application!');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Notifications/ResetPasswordNotification.php
+++ b/app/Notifications/ResetPasswordNotification.php
@@ -2,30 +2,42 @@
 
 namespace romansorin\Notifications;
 
-use Illuminate\Bus\Queueable;
+use Illuminate\Support\Facades\Lang;
 use Illuminate\Notifications\Notification;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 
 class ResetPasswordNotification extends Notification
 {
-    use Queueable;
+    /**
+     * The password reset token.
+     *
+     * @var string
+     */
+    public $token;
 
     /**
-     * Create a new notification instance.
+     * The callback that should be used to build the mail message.
      *
+     * @var \Closure|null
+     */
+    public static $toMailCallback;
+
+    /**
+     * Create a notification instance.
+     *
+     * @param  string  $token
      * @return void
      */
-    public function __construct()
+    public function __construct($token)
     {
-        //
+        $this->token = $token;
     }
 
     /**
-     * Get the notification's delivery channels.
+     * Get the notification's channels.
      *
      * @param  mixed  $notifiable
-     * @return array
+     * @return array|string
      */
     public function via($notifiable)
     {
@@ -33,29 +45,33 @@ class ResetPasswordNotification extends Notification
     }
 
     /**
-     * Get the mail representation of the notification.
+     * Build the mail representation of the notification.
      *
      * @param  mixed  $notifiable
      * @return \Illuminate\Notifications\Messages\MailMessage
      */
     public function toMail($notifiable)
     {
+        if (static::$toMailCallback) {
+            return call_user_func(static::$toMailCallback, $notifiable, $this->token);
+        }
+
         return (new MailMessage)
-                    ->line('The introduction to the notification.')
-                    ->action('Notification Action', url('/'))
-                    ->line('Thank you for using our application!');
+            ->subject(Lang::getFromJson('Reset Password Notification'))
+            ->line(Lang::getFromJson('You are receiving this email because we received a password reset request for your account.'))
+            ->action(Lang::getFromJson('Reset Password'), url(route('password.reset', ['token' => $this->token], false)))
+            ->line(Lang::getFromJson('This password reset link will expire in :count minutes.', ['count' => config('auth.passwords.users.expire')]))
+            ->line(Lang::getFromJson('If you did not request a password reset, no further action is required.'));
     }
 
     /**
-     * Get the array representation of the notification.
+     * Set a callback that should be used when building the notification mail message.
      *
-     * @param  mixed  $notifiable
-     * @return array
+     * @param  \Closure  $callback
+     * @return void
      */
-    public function toArray($notifiable)
+    public static function toMailUsing($callback)
     {
-        return [
-            //
-        ];
+        static::$toMailCallback = $callback;
     }
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -4,6 +4,8 @@ namespace romansorin\Providers;
 
 use Illuminate\Support\Facades\Event;
 use Illuminate\Auth\Events\Registered;
+// use Illuminate\Auth\Events\Verified;
+// use Illuminate\Support\Facades\App\Listeners\LogVerifiedUser;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
@@ -18,6 +20,9 @@ class EventServiceProvider extends ServiceProvider
         Registered::class => [
             SendEmailVerificationNotification::class,
         ],
+        // Verified::class => [
+        //     LogVerifiedUser::class
+        // ]
     ];
 
     /**

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -23,8 +23,6 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
-
         parent::boot();
     }
 
@@ -38,8 +36,6 @@ class RouteServiceProvider extends ServiceProvider
         $this->mapApiRoutes();
 
         $this->mapWebRoutes();
-
-        //
     }
 
     /**
@@ -52,8 +48,8 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapWebRoutes()
     {
         Route::middleware('web')
-             ->namespace($this->namespace)
-             ->group(base_path('routes/web.php'));
+            ->namespace($this->namespace)
+            ->group(base_path('routes/web.php'));
     }
 
     /**
@@ -66,8 +62,8 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapApiRoutes()
     {
         Route::prefix('api')
-             ->middleware('api')
-             ->namespace($this->namespace)
-             ->group(base_path('routes/api.php'));
+            ->middleware('api')
+            ->namespace($this->namespace)
+            ->group(base_path('routes/api.php'));
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -6,7 +6,7 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     use Notifiable;
 

--- a/app/User.php
+++ b/app/User.php
@@ -4,9 +4,10 @@ namespace romansorin;
 
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Contracts\Auth\CanResetPassword;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
-class User extends Authenticatable implements MustVerifyEmail
+class User extends Authenticatable implements MustVerifyEmail, CanResetPassword
 {
     use Notifiable;
 
@@ -36,4 +37,14 @@ class User extends Authenticatable implements MustVerifyEmail
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+    /**
+     * Send the password reset notification.
+     *
+     * @param  string  $token
+     * @return void
+     */
+    public function sendPasswordResetNotification($token)
+    {
+        $this->notify(new ResetPasswordNotification($token));
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -6,6 +6,7 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Contracts\Auth\CanResetPassword;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use romansorin\Notifications\ResetPasswordNotification;
 
 class User extends Authenticatable implements MustVerifyEmail, CanResetPassword
 {

--- a/config/app.php
+++ b/config/app.php
@@ -171,7 +171,7 @@ return [
          */
         romansorin\Providers\AppServiceProvider::class,
         romansorin\Providers\AuthServiceProvider::class,
-        // romansorin\Providers\BroadcastServiceProvider::class,
+        //romansorin\Providers\BroadcastServiceProvider::class,
         romansorin\Providers\EventServiceProvider::class,
         //romansorin\Providers\TelescopeServiceProvider::class,
         romansorin\Providers\RouteServiceProvider::class,

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -55127,6 +55127,13 @@ feather.replace(); // Hotjar Tracking Code for https://www.romansorin.com
   a.appendChild(r);
 })(window, document, 'https://static.hotjar.com/c/hotjar-', '.js?sv=');
 
+(document.querySelectorAll('.notification .delete') || []).forEach(function ($delete) {
+  $notification = $delete.parentNode;
+  $delete.addEventListener('click', function () {
+    $notification.parentNode.removeChild($notification);
+  });
+});
+
 /***/ }),
 
 /***/ "./resources/js/bootstrap.js":

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -17,7 +17,7 @@ const files = require.context('./', true, /\.vue$/i)
 files.keys().map(key => Vue.component(key.split('/').pop().split('.')[0], files(key).default))
 
 const app = new Vue({
-  el: '#app'
+    el: '#app'
 });
 
 // Get all "navbar-burger" elements
@@ -46,8 +46,8 @@ feather.replace();
 
 // Hotjar Tracking Code for https://www.romansorin.com
 (function (h, o, t, j, a, r) {
-  h.hj = h.hj || function () {
-    (h.hj.q = h.hj.q || []).push(arguments)
+    h.hj = h.hj || function () {
+        (h.hj.q = h.hj.q || []).push(arguments)
     };
     h._hjSettings = {
         hjid: 1327317,
@@ -59,3 +59,12 @@ feather.replace();
     r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
     a.appendChild(r);
 })(window, document, 'https://static.hotjar.com/c/hotjar-', '.js?sv=');
+
+
+
+(document.querySelectorAll('.notification .delete') || []).forEach(($delete) => {
+    $notification = $delete.parentNode;
+    $delete.addEventListener('click', () => {
+        $notification.parentNode.removeChild($notification);
+    });
+});

--- a/resources/js/bulma-extensions.js
+++ b/resources/js/bulma-extensions.js
@@ -1,4 +1,3 @@
-
 var bulmaAccordion = require('bulma-extensions/bulma-accordion/dist/js/bulma-accordion');
 var bulmaCalendar = require('bulma-extensions/bulma-calendar/dist/js/bulma-calendar');
 var bulmaCarousel = require('bulma-extensions/bulma-carousel/dist/js/bulma-carousel');

--- a/resources/views/auth/dashboard.blade.php
+++ b/resources/views/auth/dashboard.blade.php
@@ -6,10 +6,11 @@
         <div class="box">
             <h1 class="title">Dashboard</h1>
             @if (session('status'))
-            <div class="alert alert-success" role="alert">
+            <div class="notification is-success" role="alert">
+                <button class="delete"></button>
                 {{ session('status') }}
             </div>
-        @endif
+            @endif
             <h2 class="subtitle">You are logged in!</h2>
         </div>
     </div>

--- a/resources/views/auth/dashboard.blade.php
+++ b/resources/views/auth/dashboard.blade.php
@@ -1,23 +1,17 @@
 @extends('layouts.auth')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">Dashboard</div>
-
-                <div class="card-body">
-                    @if (session('status'))
-                        <div class="alert alert-success" role="alert">
-                            {{ session('status') }}
-                        </div>
-                    @endif
-
-                    You are logged in!
-                </div>
+<section class="section">
+    <div class="container">
+        <div class="box">
+            <h1 class="title">Dashboard</h1>
+            @if (session('status'))
+            <div class="alert alert-success" role="alert">
+                {{ session('status') }}
             </div>
+        @endif
+            <h2 class="subtitle">You are logged in!</h2>
         </div>
     </div>
-</div>
+</section>
 @endsection

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -16,8 +16,9 @@
                 <div class="field">
                     <label class="label" for="email">Email</label>
                     <div class="control">
-                        <input class="input{{ $errors->has('email') ? ' is-danger' : '' }}" name="email" type="email"
-                            placeholder="you@email.com" value="{{ old('email') }}" required aria-required="true">
+                        <input class="input{{ $errors->has('email') ? ' is-danger' : '' }}" id="email" name="email"
+                            type="email" placeholder="you@email.com" value="{{ old('email') }}" required
+                            aria-required="true">
                     </div>
                     @if ($errors->has('email'))
                     <p class="help is-danger" role="alert">{{ $errors->first('email') }}</p>
@@ -27,8 +28,8 @@
                 <div class="field">
                     <label class="label" for="password">Password</label>
                     <div class="control">
-                        <input class="input{{ $errors->has('password') ? ' is-danger' : '' }}" name="password"
-                            type="password" placeholder="Password" required aria-required="true">
+                        <input class="input{{ $errors->has('password') ? ' is-danger' : '' }}" id="password"
+                            name="password" type="password" placeholder="Password" required aria-required="true">
                     </div>
                     @if ($errors->has('password'))
                     <p class="help is-danger" role="alert">{{ $errors->first('password') }}</p>
@@ -52,7 +53,8 @@
                     </div>
                     @if (Route::has('password.request'))
                     <div class="control">
-                        <a class="button is-text" href="{{ route('password.request') }}">Forgot Your Password?</a>
+                        <a class="button is-text" id="forgot-password" href="{{ route('password.request') }}">Forgot
+                            Your Password?</a>
                     </div>
                     @endif
                 </div>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,73 +1,63 @@
-@extends('layouts.app')
+@extends('layouts.auth')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Login') }}</div>
+<section class="section">
+    <div class="container">
+        <h1 class="title">Login</h1>
+        <h2 class="subtitle">Login to your existing account.</h2>
+    </div>
+</section>
+<section class="section">
+    <div class="container">
+        <div class="box">
+            <form method="POST" action="{{ route('login') }}">
+                @csrf
 
-                <div class="card-body">
-                    <form method="POST" action="{{ route('login') }}">
-                        @csrf
-
-                        <div class="form-group row">
-                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ old('email') }}" required autofocus>
-
-                                @if ($errors->has('email'))
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $errors->first('email') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="password" class="col-md-4 col-form-label text-md-right">{{ __('Password') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}" name="password" required>
-
-                                @if ($errors->has('password'))
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $errors->first('password') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <div class="col-md-6 offset-md-4">
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" name="remember" id="remember" {{ old('remember') ? 'checked' : '' }}>
-
-                                    <label class="form-check-label" for="remember">
-                                        {{ __('Remember Me') }}
-                                    </label>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="form-group row mb-0">
-                            <div class="col-md-8 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Login') }}
-                                </button>
-
-                                @if (Route::has('password.request'))
-                                    <a class="btn btn-link" href="{{ route('password.request') }}">
-                                        {{ __('Forgot Your Password?') }}
-                                    </a>
-                                @endif
-                            </div>
-                        </div>
-                    </form>
+                <div class="field">
+                    <label class="label" for="email">Email</label>
+                    <div class="control">
+                        <input class="input{{ $errors->has('email') ? ' is-danger' : '' }}" name="email" type="email"
+                            placeholder="you@email.com" value="{{ old('email') }}" required aria-required="true">
+                    </div>
+                    @if ($errors->has('email'))
+                    <p class="help is-danger" role="alert">{{ $errors->first('email') }}</p>
+                    @endif
                 </div>
-            </div>
+
+                <div class="field">
+                    <label class="label" for="password">Password</label>
+                    <div class="control">
+                        <input class="input{{ $errors->has('password') ? ' is-danger' : '' }}" name="password"
+                            type="password" placeholder="Password" required aria-required="true">
+                    </div>
+                    @if ($errors->has('password'))
+                    <p class="help is-danger" role="alert">{{ $errors->first('password') }}</p>
+                    @endif
+                </div>
+
+                <div class="field">
+                    <div class="control">
+                        {{-- Use Bulma extension checkbox here --}}
+                        <label class="checkbox" for="remember">
+                            <input type="checkbox" name="remember" id="remember" {{ old('remember') ? 'checked' : '' }}
+                                aria-required="false">
+                            Remember Me
+                        </label>
+                    </div>
+                </div>
+
+                <div class="field is-grouped">
+                    <div class="control">
+                        <button type="submit" class="button is-primary">Login</button>
+                    </div>
+                    @if (Route::has('password.request'))
+                    <div class="control">
+                        <a class="button is-text" href="{{ route('password.request') }}">Forgot Your Password?</a>
+                    </div>
+                    @endif
+                </div>
+            </form>
         </div>
     </div>
-</div>
+</section>
 @endsection

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -36,15 +36,11 @@
                     @endif
                 </div>
 
+
                 <div class="field">
-                    <div class="control">
-                        {{-- Use Bulma extension checkbox here --}}
-                        <label class="checkbox" for="remember">
-                            <input type="checkbox" name="remember" id="remember" {{ old('remember') ? 'checked' : '' }}
-                                aria-required="false">
-                            Remember Me
-                        </label>
-                    </div>
+                    <input class="is-checkradio" type="checkbox" name="remember" id="remember"
+                        {{ old('remember') ? 'checked' : '' }} aria-required="false">
+                    <label class="is-marginless" for="remember">Remember Me</label>
                 </div>
 
                 <div class="field is-grouped">

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app')
+@extends('layouts.auth')
 
 @section('content')
 <div class="container">

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -1,47 +1,43 @@
 @extends('layouts.auth')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Reset Password') }}</div>
+<section class="section">
+    <div class="container">
+        <div class="box">
+            <h1 class="title">{{ __('Reset Password') }}</h1>
 
-                <div class="card-body">
-                    @if (session('status'))
-                        <div class="alert alert-success" role="alert">
-                            {{ session('status') }}
-                        </div>
-                    @endif
-
-                    <form method="POST" action="{{ route('password.email') }}">
-                        @csrf
-
-                        <div class="form-group row">
-                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ old('email') }}" required>
-
-                                @if ($errors->has('email'))
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $errors->first('email') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Send Password Reset Link') }}
-                                </button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
+            {{-- What Bulma classes for this? --}}
+            @if (session('status'))
+            <div class="alert alert-success" role="alert">
+                {{ session('status') }}
             </div>
+            @endif
+
+            <form method="POST" action="{{ route('password.email') }}">
+                @csrf
+
+                <div class="field">
+                    <label for="email" class="label">{{ __('E-Mail Address') }}</label>
+                    <div class="control">
+                        <input id="email" type="email" class="input{{ $errors->has('email') ? ' is-danger' : '' }}"
+                            name="email" value="{{ old('email') }}" required>
+                    </div>
+                    @if ($errors->has('email'))
+                    <p class="help is-danger" role="alert">
+                        {{ $errors->first('email') }}
+                    </p>
+                    @endif
+                </div>
+
+                <div class="field">
+                    <div class="control">
+                        <button type="submit" class="button is-primary">
+                            {{ __('Send Password Reset Link') }}
+                        </button>
+                    </div>
+                </div>
+            </form>
         </div>
     </div>
-</div>
+</section>
 @endsection

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -6,9 +6,9 @@
         <div class="box">
             <h1 class="title">{{ __('Reset Password') }}</h1>
 
-            {{-- What Bulma classes for this? --}}
             @if (session('status'))
-            <div class="alert alert-success" role="alert">
+            <div class="notification is-success" role="alert">
+                <button class="delete"></button>
                 {{ session('status') }}
             </div>
             @endif

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app')
+@extends('layouts.auth')
 
 @section('content')
 <div class="container">

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -1,65 +1,60 @@
 @extends('layouts.auth')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Reset Password') }}</div>
+<section class="section">
+    <div class="container">
+        <div class="box">
+            <h1 class="title">{{ __('Reset Password') }}</h1>
 
-                <div class="card-body">
-                    <form method="POST" action="{{ route('password.update') }}">
-                        @csrf
+            <form method="POST" action="{{ route('password.update') }}">
+                @csrf
 
-                        <input type="hidden" name="token" value="{{ $token }}">
+                <input type="hidden" name="token" value="{{ $token }}">
 
-                        <div class="form-group row">
-                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
+                <div class="field">
+                    <label for="email" class="label">{{ __('E-Mail Address') }}</label>
+                    <div class="control">
+                        <input id="email" type="email" class="input{{ $errors->has('email') ? ' is-danger' : '' }}"
+                            name="email" value="{{ $email ?? old('email') }}" required autofocus>
 
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ $email ?? old('email') }}" required autofocus>
-
-                                @if ($errors->has('email'))
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $errors->first('email') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="password" class="col-md-4 col-form-label text-md-right">{{ __('Password') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}" name="password" required>
-
-                                @if ($errors->has('password'))
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $errors->first('password') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="password-confirm" class="col-md-4 col-form-label text-md-right">{{ __('Confirm Password') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required>
-                            </div>
-                        </div>
-
-                        <div class="form-group row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Reset Password') }}
-                                </button>
-                            </div>
-                        </div>
-                    </form>
+                    </div>
+                    @if ($errors->has('email'))
+                    <p class="help is-danger" role="alert">{{ $errors->first('email') }}</p>
+                    @endif
                 </div>
-            </div>
+
+                <div class="field">
+                    <label for="password" class="label">{{ __('Password') }}</label>
+
+                    <div class="col-md-6">
+                        <input id="password" type="password"
+                            class="input{{ $errors->has('password') ? ' is-danger' : '' }}" name="password" required>
+
+                        @if ($errors->has('password'))
+                        <p class="help is-danger" role="alert">{{ $errors->first('password') }}
+                        </p>
+                        @endif
+                    </div>
+                </div>
+
+                <div class="field">
+                    <label for="password-confirm" class="label">{{ __('Confirm Password') }}</label>
+
+                    <div class="control">
+                        <input id="password-confirm" type="password" class="input" name="password_confirmation"
+                            required>
+                    </div>
+                </div>
+
+                <div class="field">
+                    <div class="control">
+                        <button type="submit" class="button is-primary">
+                            {{ __('Reset Password') }}
+                        </button>
+                    </div>
+                </div>
+            </form>
         </div>
     </div>
-</div>
+</section>
 @endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app')
+@extends('layouts.auth')
 
 @section('content')
 <section class="section">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -16,8 +16,8 @@
                 <div class="field">
                     <label class="label" for="name">Name</label>
                     <div class="control">
-                        <input class="input{{ $errors->has('name') ? ' is-danger' : '' }}" name="name" type="text"
-                            placeholder="Your name" value="{{ old('name') }}" required aria-required="true">
+                        <input class="input{{ $errors->has('name') ? ' is-danger' : '' }}" id="name" name="name"
+                            type="text" placeholder="Your name" value="{{ old('name') }}" required aria-required="true">
                     </div>
                     @if ($errors->has('name'))
                     <p class="help is-danger" role="alert">{{ $errors->first('name') }}</p>
@@ -27,8 +27,9 @@
                 <div class="field">
                     <label class="label" for="email">Email</label>
                     <div class="control">
-                        <input class="input{{ $errors->has('email') ? ' is-danger' : '' }}" name="email" type="email"
-                            placeholder="you@email.com" value="{{ old('email') }}" required aria-required="true">
+                        <input class="input{{ $errors->has('email') ? ' is-danger' : '' }}" id="email" name="email"
+                            type="email" placeholder="you@email.com" value="{{ old('email') }}" required
+                            aria-required="true">
                     </div>
                     @if ($errors->has('email'))
                     <p class="help is-danger" role="alert">{{ $errors->first('email') }}</p>
@@ -38,8 +39,8 @@
                 <div class="field">
                     <label class="label" for="password">Password</label>
                     <div class="control">
-                        <input class="input{{ $errors->has('password') ? ' is-danger' : '' }}" name="password"
-                            type="password" placeholder="Password" required aria-required="true">
+                        <input class="input{{ $errors->has('password') ? ' is-danger' : '' }}" id="password"
+                            name="password" type="password" placeholder="Password" required aria-required="true">
                     </div>
                     @if ($errors->has('password'))
                     <p class="help is-danger" role="alert">{{ $errors->first('password') }}</p>
@@ -47,11 +48,11 @@
                 </div>
 
                 <div class="field">
-                    <label class="label" for="password_confirmation">Confirm password</label>
+                    <label class="label" for="password-confirm">Confirm password</label>
                     <div class="control">
                         <input class="input{{ $errors->has('password_confirmation') ? ' is-danger' : '' }}"
-                            name="password_confirmation" type="password" placeholder="Confirm password" required
-                            aria-required="true">
+                            name="password_confirmation" type="password" id="password-confirm"
+                            placeholder="Confirm password" required aria-required="true">
                     </div>
                     @if ($errors->has('password_confirmation'))
                     <p class="help is-danger" role="alert">{{ $errors->first('password_confirmation') }}</p>
@@ -62,7 +63,8 @@
                     <div class="control">
                         {{-- Use Bulma extension checkbox here --}}
                         <label class="checkbox">
-                            <input type="checkbox" name="tos" id="tos" {{ old('tos') ? 'checked' : '' }} required aria-required="true">
+                            <input type="checkbox" name="tos" id="tos" {{ old('tos') ? 'checked' : '' }} required
+                                aria-required="true">
                             I agree to the <a href="#">terms and conditions</a>.
                         </label>
                     </div>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -62,7 +62,7 @@
                     <div class="control">
                         {{-- Use Bulma extension checkbox here --}}
                         <label class="checkbox">
-                            <input type="checkbox" required aria-required="true">
+                            <input type="checkbox" name="tos" id="tos" {{ old('tos') ? 'checked' : '' }} required aria-required="true">
                             I agree to the <a href="#">terms and conditions</a>.
                         </label>
                     </div>
@@ -70,7 +70,7 @@
 
                 <div class="field">
                     <div class="control">
-                        <button type="submit" class="button is-link">Submit</button>
+                        <button type="submit" class="button is-primary">Register</button>
                     </div>
                 </div>
             </form>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,77 +1,80 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Register') }}</div>
+<section class="section">
+    <div class="container">
+        <h1 class="title">Register</h1>
+        <h2 class="subtitle">Sign-up to access all features of romansorin.com</h2>
+    </div>
+</section>
+<section class="section">
+    <div class="container">
+        <div class="box">
+            <form method="POST" action="{{ route('register') }}">
+                @csrf
 
-                <div class="card-body">
-                    <form method="POST" action="{{ route('register') }}">
-                        @csrf
-
-                        <div class="form-group row">
-                            <label for="name" class="col-md-4 col-form-label text-md-right">{{ __('Name') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="name" type="text" class="form-control{{ $errors->has('name') ? ' is-invalid' : '' }}" name="name" value="{{ old('name') }}" required autofocus>
-
-                                @if ($errors->has('name'))
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $errors->first('name') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ old('email') }}" required>
-
-                                @if ($errors->has('email'))
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $errors->first('email') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="password" class="col-md-4 col-form-label text-md-right">{{ __('Password') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}" name="password" required>
-
-                                @if ($errors->has('password'))
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $errors->first('password') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="password-confirm" class="col-md-4 col-form-label text-md-right">{{ __('Confirm Password') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required>
-                            </div>
-                        </div>
-
-                        <div class="form-group row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Register') }}
-                                </button>
-                            </div>
-                        </div>
-                    </form>
+                <div class="field">
+                    <label class="label" for="name">Name</label>
+                    <div class="control">
+                        <input class="input{{ $errors->has('name') ? ' is-danger' : '' }}" name="name" type="text"
+                            placeholder="Your name" value="{{ old('name') }}" required aria-required="true">
+                    </div>
+                    @if ($errors->has('name'))
+                    <p class="help is-danger" role="alert">{{ $errors->first('name') }}</p>
+                    @endif
                 </div>
-            </div>
+
+                <div class="field">
+                    <label class="label" for="email">Email</label>
+                    <div class="control">
+                        <input class="input{{ $errors->has('email') ? ' is-danger' : '' }}" name="email" type="email"
+                            placeholder="you@email.com" value="{{ old('email') }}" required aria-required="true">
+                    </div>
+                    @if ($errors->has('email'))
+                    <p class="help is-danger" role="alert">{{ $errors->first('email') }}</p>
+                    @endif
+                </div>
+
+                <div class="field">
+                    <label class="label" for="password">Password</label>
+                    <div class="control">
+                        <input class="input{{ $errors->has('password') ? ' is-danger' : '' }}" name="password"
+                            type="password" placeholder="Password" required aria-required="true">
+                    </div>
+                    @if ($errors->has('password'))
+                    <p class="help is-danger" role="alert">{{ $errors->first('password') }}</p>
+                    @endif
+                </div>
+
+                <div class="field">
+                    <label class="label" for="password_confirmation">Confirm password</label>
+                    <div class="control">
+                        <input class="input{{ $errors->has('password_confirmation') ? ' is-danger' : '' }}"
+                            name="password_confirmation" type="password" placeholder="Confirm password" required
+                            aria-required="true">
+                    </div>
+                    @if ($errors->has('password_confirmation'))
+                    <p class="help is-danger" role="alert">{{ $errors->first('password_confirmation') }}</p>
+                    @endif
+                </div>
+
+                <div class="field">
+                    <div class="control">
+                        {{-- Use Bulma extension checkbox here --}}
+                        <label class="checkbox">
+                            <input type="checkbox" required aria-required="true">
+                            I agree to the <a href="#">terms and conditions</a>.
+                        </label>
+                    </div>
+                </div>
+
+                <div class="field">
+                    <div class="control">
+                        <button type="submit" class="button is-link">Submit</button>
+                    </div>
+                </div>
+            </form>
         </div>
     </div>
-</div>
+</section>
 @endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -60,14 +60,9 @@
                 </div>
 
                 <div class="field">
-                    <div class="control">
-                        {{-- Use Bulma extension checkbox here --}}
-                        <label class="checkbox">
-                            <input type="checkbox" name="tos" id="tos" {{ old('tos') ? 'checked' : '' }} required
-                                aria-required="true">
-                            I agree to the <a href="#">terms and conditions</a>.
-                        </label>
-                    </div>
+                    <input class="is-checkradio" id="tos" type="checkbox" name="tos" {{ old('tos') ? 'checked' : '' }}
+                        required aria-required="true">
+                    <label class="is-marginless" for="tos">I agree to the <a href="#">terms and conditions</a>.</label>
                 </div>
 
                 <div class="field">

--- a/resources/views/auth/verify.blade.php
+++ b/resources/views/auth/verify.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app')
+@extends('layouts.auth')
 
 @section('content')
 <div class="container">

--- a/resources/views/auth/verify.blade.php
+++ b/resources/views/auth/verify.blade.php
@@ -10,12 +10,11 @@
                 {{ __('A fresh verification link has been sent to your email address.') }}
             </div>
             @endif
-            <div class="card-body">
-
+            <h2 class="subtitle">
                 {{ __('Before proceeding, please check your email for a verification link.') }}
                 {{ __('If you did not receive the email') }}, <a
                     href="{{ route('verification.resend') }}">{{ __('click here to request another') }}</a>.
-            </div>
+            </h2>
         </div>
     </div>
 </section>

--- a/resources/views/auth/verify.blade.php
+++ b/resources/views/auth/verify.blade.php
@@ -1,24 +1,22 @@
 @extends('layouts.auth')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Verify Your Email Address') }}</div>
+<section class="section">
+    <div class="container">
+        <div class="box">
+            <h1 class="title">Verify Your Email Address</h1>
+            @if (session('resent'))
+            <div class="alert alert-success" role="alert">
+                {{ __('A fresh verification link has been sent to your email address.') }}
+            </div>
+            @endif
+            <div class="card-body">
 
-                <div class="card-body">
-                    @if (session('resent'))
-                        <div class="alert alert-success" role="alert">
-                            {{ __('A fresh verification link has been sent to your email address.') }}
-                        </div>
-                    @endif
-
-                    {{ __('Before proceeding, please check your email for a verification link.') }}
-                    {{ __('If you did not receive the email') }}, <a href="{{ route('verification.resend') }}">{{ __('click here to request another') }}</a>.
-                </div>
+                {{ __('Before proceeding, please check your email for a verification link.') }}
+                {{ __('If you did not receive the email') }}, <a
+                    href="{{ route('verification.resend') }}">{{ __('click here to request another') }}</a>.
             </div>
         </div>
     </div>
-</div>
+</section>
 @endsection

--- a/resources/views/auth/verify.blade.php
+++ b/resources/views/auth/verify.blade.php
@@ -6,7 +6,8 @@
         <div class="box">
             <h1 class="title">Verify Your Email Address</h1>
             @if (session('resent'))
-            <div class="alert alert-success" role="alert">
+            <div class="notification is-success" role="alert">
+                <button class="delete"></button>
                 {{ __('A fresh verification link has been sent to your email address.') }}
             </div>
             @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,9 +5,8 @@
 // Public Routes //
 ///////////////////
 Route::domain('dashboard.romanserver')->group(function() {
-    Auth::routes();
+    Auth::routes(['verify' => true]);
     Route::get('/', 'DashboardController@index')->name('dashboard');
-
 });
 
 // portfolio

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,10 +1,12 @@
 <?php
 
+// FOR AUTH STUFF, USE OUTGOING EMAIL: SECURITY@ROMANSORIN.COM
+
 // dashboard
 ///////////////////
 // Public Routes //
 ///////////////////
-Route::domain('dashboard.romanserver')->group(function() {
+Route::domain('dashboard.romanserver')->group(function () {
     Auth::routes(['verify' => true]);
     Route::get('/', 'DashboardController@index')->name('dashboard');
 });
@@ -13,23 +15,21 @@ Route::domain('dashboard.romanserver')->group(function() {
 ///////////////////
 // Public Routes //
 ///////////////////
-Route::domain('romanserver')->group(function() {
-
-Route::get('/', function () {
-    return view('welcome');
-});
-Route::get('/about', function () {
-    return view('about');
-});
-Route::get('/contact', function () {
-    return view('contact');
-});
-// Route::post('/contact', 'ContactFormController@store');
-Route::get('/insights', function () {
+Route::domain('romanserver')->group(function () {
+    Route::get('/', function () {
+        return view('welcome');
+    });
+    Route::get('/about', function () {
+        return view('about');
+    });
+    Route::get('/contact', function () {
+        return view('contact');
+    });
+    // Route::post('/contact', 'ContactFormController@store');
+    Route::get('/insights', function () {
         return view('insights');
-});
-Route::get('/works', function () {
+    });
+    Route::get('/works', function () {
         return view('works');
+    });
 });
-});
-

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,7 @@
 <?php
 
 // FOR AUTH STUFF, USE OUTGOING EMAIL: SECURITY@ROMANSORIN.COM
-
+// Eventually, change the dashboard route of all password / email related things to something different (i.e., not /password/reset or /email/verify). For now, it's functional
 // dashboard
 ///////////////////
 // Public Routes //


### PR DESCRIPTION
When using the default reset notification generated by make:auth, the reset link in the subsequent email fails to properly point to the subdomain dashboard.APP_URL.

Because dashboard is the subdomain route that handles all authentication and associated functions/routes/etc., it is necessary that all related links point to this subdomain. Otherwise, a 404 will occur, as APP_URL by itself (in this case, romansorin.com) only handles the public facing portfolio component of this app. 